### PR TITLE
Update handleLabelClick to check for child options

### DIFF
--- a/src/components/CurvedBottomNavigation.vue
+++ b/src/components/CurvedBottomNavigation.vue
@@ -245,7 +245,7 @@ function cssLoader() {
   head.appendChild(style);
 }
 function handleLabelClick(button: CurvedOption) {
-  if (!showable.value || button.isActive) {
+  if ((!showable.value || button.isActive) && hasChild(button)) {
     toggleClass();
   }
 


### PR DESCRIPTION
To display child menus, you need to make sure you click on a menu item that has a child menu.